### PR TITLE
Disable gretty file logging

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/SpringSampleWarPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/SpringSampleWarPlugin.groovy
@@ -40,6 +40,7 @@ public class SpringSampleWarPlugin extends SpringSamplePlugin {
 		project.gretty {
 			servletContainer = 'tomcat8'
 			contextPath = '/'
+			fileLogEnabled = false
 		}
 
 		project.tasks.withType(Test).all { task ->


### PR DESCRIPTION
By default, gretty outputs logs to both console and log file (see [gretty logging reference](https://akhikhl.github.io/gretty-doc/Logging.html)), with default location for log file being `$HOME/logs`. This is IMO somewhat annoying since it causes the build to generate files outside of project directory.

This PR updates `SpringSampleWarPlugin` to disable gretty's log file.