### PR TITLE
Fix docs convention plugin configuration

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/DocsPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/DocsPlugin.groovy
@@ -53,23 +53,23 @@ public class DocsPlugin implements Plugin<Project> {
 			def ghTag = 'master'//snapshotBuild ? 'master' : project.version
 			def ghUrl = "https://github.com/spring-projects/${projectName}/tree/$ghTag"
 			options = [
-			  eruby: 'erubis',
-			  attributes: [
-				  copycss : '',
-				  icons : 'font',
-				  'source-highlighter': 'prettify',
-				  sectanchors : '',
-				  toc2: '',
-				  idprefix: '',
-				  idseparator: '-',
-				  doctype: 'book',
-				  numbered: '',
-				  '${projectName}-version' : project.version,
-				  revnumber : project.version,
-				  'gh-url': ghUrl,
-				  'gh-samples-url': "$ghUrl/samples",
-				  docinfo : ""
-			  ]
+					eruby: 'erubis',
+			]
+			attributes = [
+					copycss : '',
+					icons : 'font',
+					'source-highlighter': 'prettify',
+					sectanchors : '',
+					toc2: '',
+					idprefix: '',
+					idseparator: '-',
+					doctype: 'book',
+					numbered: '',
+					'${projectName}-version' : project.version,
+					revnumber : project.version,
+					'gh-url': ghUrl,
+					'gh-samples-url': "$ghUrl/samples",
+					docinfo : ""
 			]
 		}
 


### PR DESCRIPTION
This commit updates `asciidoctor` task configuration to prevent deprecation warnings:

```
Attributes found in options. Existing attributes will be replaced due to assignment. Please use 'attributes' method instead as current behaviour will be removed in future
```

See [Travis CI build](https://travis-ci.org/spring-projects/spring-session/builds/251222001#L170) as an example.