### PR TITLE
Exclude test scoped dependencies from generated POM

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/SpringMavenPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/SpringMavenPlugin.groovy
@@ -141,6 +141,7 @@ public class SpringMavenPlugin implements Plugin<Project> {
 
 	private static void configurePom(Project project, MavenPom pom) {
 		pom.whenConfigured { p ->
+			p.dependencies.removeAll { it.scope == 'test' }
 			p.dependencies = p.dependencies.sort { dep ->
 				"$dep.scope:$dep.optional:$dep.groupId:$dep.artifactId"
 			}


### PR DESCRIPTION
This PR updates `SpringMavenPlugin` to prevent inclusion of test scoped dependencies in the generated POM.