### PR TITLE
Remove a duplicate property in RootProjectPlugin

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/RootProjectPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/RootProjectPlugin.groovy
@@ -24,7 +24,6 @@ public class RootProjectPlugin implements Plugin<Project> {
 				property "sonar.links.issue", "https://github.com/spring-projects/${projectName}/issues"
 				property "sonar.links.scm", "https://github.com/spring-projects/${projectName}"
 				property "sonar.links.scm_dev", "https://github.com/spring-projects/${projectName}.git"
-				property "sonar.java.coveragePlugin", "jacoco"
 			}
 		}
 


### PR DESCRIPTION
This PR removes a duplicate property in `RootProjectPlugin`.