### PR TITLE
Add spring-javaformat to Checkstyle convention

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/CheckstylePlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/CheckstylePlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,6 +35,7 @@ class CheckstylePlugin implements Plugin<Project> {
 			def checkstyleDir = project.rootProject.file(CHECKSTYLE_DIR)
 			if (checkstyleDir.exists() && checkstyleDir.directory) {
 				project.getPluginManager().apply('checkstyle')
+				project.dependencies.add('checkstyle', 'io.spring.javaformat:spring-javaformat-checkstyle:0.0.5')
 
 				project.checkstyle {
 					configFile = project.rootProject.file("$CHECKSTYLE_DIR/checkstyle.xml")


### PR DESCRIPTION
This PR enhances the Checkstyle convention plugin to add `io.spring.javaformat:spring-javaformat-checkstyle` dependency to Checkstyle classpath.