### PR TITLE
Fix integration test report locations

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/IntegrationTestPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/IntegrationTestPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,12 +16,11 @@
 package io.spring.gradle.convention
 
 import io.spring.gradle.propdeps.PropDepsPlugin
-import org.gradle.api.plugins.GroovyPlugin
-import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.plugins.GroovyPlugin
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.testing.Test
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
@@ -77,10 +76,6 @@ public class IntegrationTestPlugin implements Plugin<Project> {
 			dependsOn 'jar'
 			testClassesDirs = project.sourceSets.integrationTest.output.classesDirs
 			classpath = project.sourceSets.integrationTest.runtimeClasspath
-			reports {
-				html.destination = project.file("$project.buildDir/reports/integration-tests/")
-				junitXml.destination = project.file("$project.buildDir/integration-test-results/")
-			}
 			shouldRunAfter project.tasks.test
 		}
 		project.tasks.check.dependsOn integrationTestTask

--- a/src/test/groovy/io/spring/gradle/convention/IntegrationTestPluginITest.groovy
+++ b/src/test/groovy/io/spring/gradle/convention/IntegrationTestPluginITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -33,8 +33,8 @@ class IntegrationTestPluginITest extends Specification {
 		then:
 		result.task(":check").outcome == SUCCESS
 		and:
-		new File(testKit.getRootDir(), 'build/integration-test-results/').exists()
-		new File(testKit.getRootDir(), 'build/reports/integration-tests/').exists()
+		new File(testKit.getRootDir(), 'build/test-results/integrationTest/').exists()
+		new File(testKit.getRootDir(), 'build/reports/tests/integrationTest/').exists()
 	}
 
 	def "check with propdeps"() {
@@ -45,8 +45,8 @@ class IntegrationTestPluginITest extends Specification {
 		then:
 		result.task(":check").outcome == SUCCESS
 		and:
-		new File(testKit.getRootDir(), 'build/integration-test-results/').exists()
-		new File(testKit.getRootDir(), 'build/reports/integration-tests/').exists()
+		new File(testKit.getRootDir(), 'build/test-results/integrationTest/').exists()
+		new File(testKit.getRootDir(), 'build/reports/tests/integrationTest/').exists()
 	}
 
 	def "check with groovy plugin"() {
@@ -57,7 +57,7 @@ class IntegrationTestPluginITest extends Specification {
 		then:
 		result.task(":check").outcome == SUCCESS
 		and:
-		new File(testKit.getRootDir(), 'build/integration-test-results/').exists()
-		new File(testKit.getRootDir(), 'build/reports/integration-tests/').exists()
+		new File(testKit.getRootDir(), 'build/test-results/integrationTest/').exists()
+		new File(testKit.getRootDir(), 'build/reports/tests/integrationTest/').exists()
 	}
 }

--- a/src/test/groovy/io/spring/gradle/convention/ShowcaseITest.groovy
+++ b/src/test/groovy/io/spring/gradle/convention/ShowcaseITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,8 +21,6 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
-
 class ShowcaseITest extends Specification {
 	@Rule final TestKit testKit = new TestKit()
 
@@ -38,8 +36,8 @@ class ShowcaseITest extends Specification {
 		and: 'javadoc api works'
 
 		and: 'integration tests run'
-		new File(testKit.getRootDir(), 'samples/sgbcs-sample-war/build/integration-test-results/').exists()
-		new File(testKit.getRootDir(), 'samples/sgbcs-sample-war/build/reports/integration-tests/').exists()
+		new File(testKit.getRootDir(), 'samples/sgbcs-sample-war/build/test-results/integrationTest/').exists()
+		new File(testKit.getRootDir(), 'samples/sgbcs-sample-war/build/reports/tests/integrationTest/').exists()
 	}
 
 	def "springio"() {


### PR DESCRIPTION
`IntegrationTestPlugin` currently defines the following report locations:

```groovy
html.destination = project.file("$project.buildDir/reports/integration-tests/")
junitXml.destination = project.file("$project.buildDir/integration-test-results/")
```

This is inconsistent with locations for standard tests, which are:

- `build/reports/tests/test/`
- `build/test-results/test/`

Consequently, Spring Security and Spring Session Jenkins builds, which define `junit '**/build/*-results/*.xml'` in `Jenkinsfile` end up picking only reports for integration tests.

This PR removes explicit report locations in `IntegrationTestPlugin` so that the reports end up in:

- `build/reports/tests/integrationTest/`
- `build/test-results/integrationTest/`

Consuming projects will then need to update their `Jenkinsfile` to define `junit '*/build/test-results/*/*.xml'`