### PR TITLE
Add integrationTest.compileClasspath to idea's TEST scope

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/IntegrationTestPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/IntegrationTestPlugin.groovy
@@ -89,6 +89,7 @@ public class IntegrationTestPlugin implements Plugin<Project> {
 			project.idea {
 				module {
 					testSourceDirs += project.file('src/integration-test/java')
+					scopes.TEST.plus += [ project.configurations.integrationTestCompile ]
 				}
 			}
 		}


### PR DESCRIPTION
Adding the `integrationTest` classpath configuration to the IDEA module's TEST scope will ensure that anyone building a Gradle-based project (using this Gradle plugin) with IJ will also properly have `integrationTest` dependencies declared.  Otherwise, it is not possible to compile the project in IDEA.

Closes gh-33.