### PR TITLE
Set archives configuration for default publish

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/ArtifactoryPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/ArtifactoryPlugin.groovy
@@ -40,12 +40,19 @@ class ArtifactoryPlugin implements Plugin<Project> {
 		}
 
 		project.artifactoryPublish {
-			publishConfigs 'archives'
 			publishIvy false
 			properties = [
 					'bintray.package': "${project.group}:${name}",
 					'bintray.version': "${project.version}"
 			]
+		}
+
+		project.artifactory {
+			publish {
+				defaults {
+					publishConfigs('archives')
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is a fix for [spring-security#6032](https://github.com/spring-projects/spring-security/issues/6032)