### PR TITLE
URL Cleanup

### DIFF
--- a/src/test/resources/samples/docs/simple/build.gradle
+++ b/src/test/resources/samples/docs/simple/build.gradle
@@ -7,5 +7,5 @@ asciidoctor {
 	attributes \
 		'build-gradle': project.buildFile,
 		'sourcedir': project.sourceSets.main.java.srcDirs[0],
-		'endpoint-url': 'http://example.org'
+		'endpoint-url': 'https://example.org'
 }

--- a/src/test/resources/samples/showcase/sgbcs-docs/sgbcs-docs.gradle
+++ b/src/test/resources/samples/showcase/sgbcs-docs/sgbcs-docs.gradle
@@ -5,5 +5,5 @@ asciidoctor {
 	attributes \
 		'build-gradle': project.buildFile,
 		'sourcedir': project.sourceSets.main.java.srcDirs[0],
-		'endpoint-url': 'http://example.org'
+		'endpoint-url': 'https://example.org'
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://example.org migrated to:  
  https://example.org ([https](https://example.org) result 200).