### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/MavenBomTask.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/MavenBomTask.groovy
@@ -14,7 +14,7 @@ public class MavenBomTask extends DefaultTask {
 
 	public MavenBomTask() {
 		this.group = "Generate"
-		this.description = "Generates a Maven Build of Materials (BOM). See http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies"
+		this.description = "Generates a Maven Build of Materials (BOM). See https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies"
 		this.projects = project.subprojects
 		this.bomFile = project.file("${->project.buildDir}/maven-bom/${->project.name}-${->project.version}.txt")
 		this.outputs.upToDateWhen { false }
@@ -24,7 +24,7 @@ public class MavenBomTask extends DefaultTask {
 	public void configureBom() {
 //		project.configurations.archives.artifacts.clear()
 		bomFile.parentFile.mkdirs()
-		bomFile.write("Maven Build of Materials (BOM). See http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies")
+		bomFile.write("Maven Build of Materials (BOM). See https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies")
 		project.artifacts {
 			// work around GRADLE-2406 by attaching text artifact
 			archives(bomFile)

--- a/src/main/groovy/io/spring/gradle/convention/SpringMavenPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/SpringMavenPlugin.groovy
@@ -156,10 +156,10 @@ public class SpringMavenPlugin implements Plugin<Project> {
 			}
 			name = project.name
 			description = project.name
-			url = 'http://spring.io/spring-security'
+			url = 'https://spring.io/spring-security'
 			organization {
 				name = 'spring.io'
-				url = 'http://spring.io/'
+				url = 'https://spring.io/'
 			}
 			licenses {
 				license {

--- a/src/test/groovy/io/spring/gradle/convention/ShowcaseITest.groovy
+++ b/src/test/groovy/io/spring/gradle/convention/ShowcaseITest.groovy
@@ -98,12 +98,12 @@ class ShowcaseITest extends Specification {
 
 		and: 'adds description & url'
 		pomText.contains('<description>sgbcs-core</description>')
-		pomText.contains('<url>http://spring.io/spring-security</url>')
+		pomText.contains('<url>https://spring.io/spring-security</url>')
 
 		and: 'adds organization'
 		pomText.replaceAll('\\s','').contains('''<organization>
 			<name>spring.io</name>
-			<url>http://spring.io/</url>
+			<url>https://spring.io/</url>
 		</organization>'''.replaceAll('\\s',''))
 
 		and: 'adds licenses'

--- a/src/test/resources/samples/showcase/sgbcs-core/src/main/resources/org/springframework/springgradlebuildsample/config/spring-springgradlebuildsample-2.0.xsd
+++ b/src/test/resources/samples/showcase/sgbcs-core/src/main/resources/org/springframework/springgradlebuildsample/config/spring-springgradlebuildsample-2.0.xsd
@@ -6,7 +6,7 @@
            targetNamespace="http://www.springframework.org/schema/springgradlebuildsample">
 
     <xs:import namespace="http://www.springframework.org/schema/data/repository"
-                schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+                schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />
 
     <xs:attributeGroup name="context-source.attlist">
         <xs:attribute name="id" type="xs:token">
@@ -66,7 +66,7 @@
         <xs:attribute name="referral">
             <xs:annotation>
                 <xs:documentation>
-                    Defines the strategy to handle referrals, as described on http://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html.
+                    Defines the strategy to handle referrals, as described on https://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html.
                     Default is null.
                 </xs:documentation>
             </xs:annotation>

--- a/src/test/resources/samples/showcase/sgbcs-core/src/main/resources/org/springframework/springgradlebuildsample/config/spring-springgradlebuildsample-2.1.xsd
+++ b/src/test/resources/samples/showcase/sgbcs-core/src/main/resources/org/springframework/springgradlebuildsample/config/spring-springgradlebuildsample-2.1.xsd
@@ -6,7 +6,7 @@
            targetNamespace="http://www.springframework.org/schema/springgradlebuildsample">
 
     <xs:import namespace="http://www.springframework.org/schema/data/repository"
-                schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+                schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />
 
     <xs:attributeGroup name="context-source.attlist">
         <xs:attribute name="id" type="xs:token">
@@ -66,7 +66,7 @@
         <xs:attribute name="referral">
             <xs:annotation>
                 <xs:documentation>
-                    Defines the strategy to handle referrals, as described on http://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html.
+                    Defines the strategy to handle referrals, as described on https://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html.
                     Default is null.
                 </xs:documentation>
             </xs:annotation>

--- a/src/test/resources/samples/showcase/sgbcs-core/src/main/resources/org/springframework/springgradlebuildsample/config/spring-springgradlebuildsample-2.2.xsd
+++ b/src/test/resources/samples/showcase/sgbcs-core/src/main/resources/org/springframework/springgradlebuildsample/config/spring-springgradlebuildsample-2.2.xsd
@@ -6,7 +6,7 @@
            targetNamespace="http://www.springframework.org/schema/springgradlebuildsample">
 
     <xs:import namespace="http://www.springframework.org/schema/data/repository"
-                schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+                schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />
 
     <xs:attributeGroup name="context-source.attlist">
         <xs:attribute name="id" type="xs:token">
@@ -66,7 +66,7 @@
         <xs:attribute name="referral">
             <xs:annotation>
                 <xs:documentation>
-                    Defines the strategy to handle referrals, as described on http://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html.
+                    Defines the strategy to handle referrals, as described on https://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html.
                     Default is null.
                 </xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html with 3 occurrences migrated to:  
  https://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html ([https](https://docs.oracle.com/javase/jndi/tutorial/ldap/referral/jndi.html) result 200).
* [ ] http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html with 2 occurrences migrated to:  
  https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html ([https](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html) result 200).
* [ ] http://spring.io/ with 2 occurrences migrated to:  
  https://spring.io/ ([https](https://spring.io/) result 200).
* [ ] http://spring.io/spring-security with 2 occurrences migrated to:  
  https://spring.io/spring-security ([https](https://spring.io/spring-security) result 200).
* [ ] http://www.springframework.org/schema/data/repository/spring-repository.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/data/repository/spring-repository.xsd ([https](https://www.springframework.org/schema/data/repository/spring-repository.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/data/repository with 6 occurrences
* http://www.springframework.org/schema/ldap with 3 occurrences
* http://www.springframework.org/schema/springgradlebuildsample with 3 occurrences
* http://www.w3.org/2001/XMLSchema with 3 occurrences