### PR TITLE
Upgrade dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id "java-gradle-plugin"
-	id "com.jfrog.artifactory" version '4.9.3'
-	id 'com.github.ben-manes.versions' version '0.21.0'
+	id "com.jfrog.artifactory" version '4.9.10'
+	id 'com.github.ben-manes.versions' version '0.25.0'
 }
 
 apply plugin: 'java'
@@ -28,22 +28,22 @@ configurations {
 dependencies {
 	implementation localGroovy()
 
-	implementation 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
+	implementation 'com.github.ben-manes:gradle-versions-plugin:0.25.0'
 	implementation 'gradle.plugin.org.gretty:gretty:2.3.1'
-	implementation 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.20.0'
+	implementation 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.1'
 	implementation 'io.spring.gradle:dependency-management-plugin:1.0.8.RELEASE'
 	implementation 'io.spring.gradle:docbook-reference-plugin:0.3.1'
 	implementation 'io.spring.gradle:propdeps-plugin:0.0.10.RELEASE'
 	implementation 'io.spring.javaformat:spring-javaformat-gradle-plugin:0.0.15'
 	implementation 'io.spring.nohttp:nohttp-gradle:0.0.3.RELEASE'
-	implementation 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8.1'
-	implementation 'org.hidetake:gradle-ssh-plugin:2.9.0'
-	implementation 'org.jfrog.buildinfo:build-info-extractor-gradle:4.9.3'
-	implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.0.1622'
+	implementation 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.12'
+	implementation 'org.hidetake:gradle-ssh-plugin:2.10.1'
+	implementation 'org.jfrog.buildinfo:build-info-extractor-gradle:4.9.10'
+	implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.1'
 
 	testImplementation 'junit:junit:4.12'
 	testImplementation 'org.apache.commons:commons-io:1.3.2'
-	testImplementation 'org.assertj:assertj-core:3.12.1'
-	testImplementation 'org.mockito:mockito-core:2.25.0'
-	testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
+	testImplementation 'org.assertj:assertj-core:3.13.2'
+	testImplementation 'org.mockito:mockito-core:3.0.0'
+	testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }


### PR DESCRIPTION
- Asciidoctor Gradle Plugin: `1.5.8.1` -> `1.5.12`
- AssertJ: `3.12.1` -> `3.13.2`
- Gradle Artifactory Plugin: `4.9.3` -> `4.9.10`
- Gradle Nexus Staging Plugin: `0.20.0` -> `0.21.1`
- Gradle SSH Plugin: `2.9.0` -> `2.10.1`
- Gradle Versions Plugin: `0.21.0` -> `0.25.0`
- Mockito: `2.25.0` -> `3.0.0`
- Sonarqube Gradle Plugin: `2.7.0.1622` -> `2.7.1`
- Spock: `1.1-groovy-2.4` -> `1.3-groovy-2.5`

Tested against both Spring Security and Spring Session builds.