### PR TITLE
Add branching logic for keys in deploy docs and schema steps

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/DeployDocsPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/DeployDocsPlugin.groovy
@@ -36,8 +36,10 @@ public class DeployDocsPlugin implements Plugin<Project> {
 				retryCount = 5 // retry 5 times (default is 0)
 				retryWaitSec = 10 // wait 10 seconds between retries (default is 0)
 				user = project.findProperty('deployDocsSshUsername')
-				if(project.hasProperty('deployDocsSshKeyPath')) {
+				if (project.hasProperty('deployDocsSshKeyPath')) {
 					identity = project.file(project.findProperty('deployDocsSshKeyPath'))
+				} else if (project.hasProperty('deployDocsSshKey')) {
+					identity = project.findProperty('deployDocsSshKey')
 				}
 				if(project.hasProperty('deployDocsSshPassphrase')) {
 					passphrase = project.findProperty('deployDocsSshPassphrase')

--- a/src/main/groovy/io/spring/gradle/convention/SchemaDeployPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/SchemaDeployPlugin.groovy
@@ -23,6 +23,8 @@ public class SchemaDeployPlugin implements Plugin<Project> {
 				user = project.findProperty('deployDocsSshUsername')
 				if(project.hasProperty('deployDocsSshKeyPath')) {
 					identity = project.file(project.findProperty('deployDocsSshKeyPath'))
+				} else if (project.hasProperty('deployDocsSshKey')) {
+					identity = project.findProperty('deployDocsSshKey')
 				}
 				if(project.hasProperty('deployDocsSshPassphrase')) {
 					passphrase = project.findProperty('deployDocsSshPassphrase')


### PR DESCRIPTION
We need the ability to set SSH keys as string values for the upcoming spring-security deployment move to Github Actions. This PR adds conditional logic that sets the `identity` value used by the hidetake plugin to a string if a property argument by the name of `deployDocsSshKey` is given.