### PR TITLE
Add optional deployDocsHost flag for schema step

### DIFF
--- a/src/main/groovy/io/spring/gradle/convention/SchemaDeployPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/convention/SchemaDeployPlugin.groovy
@@ -17,7 +17,11 @@ public class SchemaDeployPlugin implements Plugin<Project> {
 		project.remotes {
 			docs {
 				role 'docs'
-				host = 'docs.af.pivotal.io'
+				if (project.hasProperty('deployDocsHost')) {
+					host = project.findProperty('deployDocsHost')
+				} else {
+					host = 'docs.af.pivotal.io'
+				}
 				retryCount = 5 // retry 5 times (default is 0)
 				retryWaitSec = 10 // wait 10 seconds between retries (default is 0)
 				user = project.findProperty('deployDocsSshUsername')


### PR DESCRIPTION
We need to be able to set the host to a different value for builds that run on Github Actions. This change adds logic to optionally set the host to the value passed in via the deployDocsHost -P flag. If none is provided, it will use the default docs.af.pivotal.io value.